### PR TITLE
Store calibration on camera optionally.

### DIFF
--- a/include/dr_ensenso_node/ensenso_calibrator.hpp
+++ b/include/dr_ensenso_node/ensenso_calibrator.hpp
@@ -64,12 +64,15 @@ private:
 		dr::ServiceClient<dr_ensenso_msgs::FinalizeCalibration> finalize_calibration;
 	} services_;
 
+	bool store_calibration_ = true;
+
 public:
 	EnsensoCalibratorNode(
 		std::string const & initialize_calibration_service, ///< Service name for the initialization of the calibration.
 		std::string const & record_calibration_service,     ///< Service name for the detect calibration pattern service.
 		std::string const & finalize_calibration_service,   ///< Service name for finalizing the calibration.
-		bool wait_for_services = false                      ///< If true, waits for the services to come alive.
+		bool wait_for_services = false,                     ///< If true, waits for the services to come alive.
+		bool store_calibration = true                       ///< If true, stores the calibration in the Ensenso.
 	);
 
 	/// Initializes a calibration sequence, clearing any state from previous calibration sequences.

--- a/src/ensenso.cpp
+++ b/src/ensenso.cpp
@@ -657,7 +657,7 @@ protected:
 		return true;
 	}
 
-	bool onFinalizeCalibration(dr_ensenso_msgs::FinalizeCalibration::Request &, dr_ensenso_msgs::FinalizeCalibration::Response & res) {
+	bool onFinalizeCalibration(dr_ensenso_msgs::FinalizeCalibration::Request & req, dr_ensenso_msgs::FinalizeCalibration::Response & res) {
 		auto const & camera_moving = auto_calibration.camera_moving;
 		auto const & moving_frame  = auto_calibration.moving_frame;
 		auto const & fixed_frame   = auto_calibration.fixed_frame;
@@ -695,8 +695,10 @@ protected:
 			res.iterations     = std::get<2>(calibration);
 			res.residual_error = std::get<3>(calibration);
 
-			// store result in camera
-			ensenso_camera->storeWorkspaceCalibration();
+			if (req.store_calibration) {
+				// store result in camera
+				ensenso_camera->storeWorkspaceCalibration();
+			}
 		} catch (std::runtime_error const & e) {
 			// store debug information
 			if (!auto_calibration.dump_dir.empty()) {

--- a/src/ensenso_calibrator.cpp
+++ b/src/ensenso_calibrator.cpp
@@ -6,8 +6,9 @@ EnsensoCalibratorNode::EnsensoCalibratorNode(
 	std::string const & initialize_calibration_service,
 	std::string const & record_calibration_service,
 	std::string const & finalize_calibration_service,
-	bool wait_for_services
-) {
+	bool wait_for_services,
+	bool store_calibration
+) : store_calibration_{store_calibration} {
 	// Connect the services to dr_ensenso_node.
 	services_.initialize_calibration.connect(*this, initialize_calibration_service, wait_for_services);
 	services_.record_calibration    .connect(*this, record_calibration_service, wait_for_services);
@@ -53,6 +54,7 @@ estd::result<void, estd::error> EnsensoCalibratorNode::recordCalibration(Eigen::
 estd::result<EnsensoCalibratorNode::CalibrationResult, estd::error> EnsensoCalibratorNode::finalizeCalibration() {
 	// Construct the request.
 	dr_ensenso_msgs::FinalizeCalibrationRequest request;
+	request.store_calibration = store_calibration_;
 
 	// Try to call the service.
 	try {


### PR DESCRIPTION
This PR adds a field in the request to decide whether to store the calibration on the camera or not.

Depends on https://github.com/fizyr/dr_ensenso_msgs/pull/1

@vsuryamurthy  can you review it? @hgaiser maybe you want to have a look ;)